### PR TITLE
make jackpots always free stakable in duckhouse due to tech implications

### DIFF
--- a/ride/artefacts/duck-house.ride
+++ b/ride/artefacts/duck-house.ride
@@ -63,7 +63,7 @@ func configureOracle(oracle: String, type: String) = {
         if type == "ART-HOUSE" then [ 
             IntegerEntry("static_boost",30),IntegerEntry("static_maxDucks",4),
             StringEntry("static_stakeCall","stakeNFT"),StringEntry("static_type","ART-HOUSE"),
-            StringEntry("static_JStakeCall","stakeJackpot")
+            StringEntry("static_JStakeCall","stakeNFTWithoutPerch")
         ] else throw("Unknown type!")
   [
     StringEntry("static_oracleAddress",oracle)
@@ -109,7 +109,7 @@ func stakeDuck(duckHouseId: String)={
     let filledSpots = tryGetInteger(occupiedSpotsDucksHouse(duckHouseId))
     if filledSpots == maxDucks() then throw("No space in duck house left!") else
     strict boostDuck = invoke(getItemsAddress(),"manipulateBoost",[boost(),assetId.toBase58String()],[])
-    strict stakeDuck = if isJackpot(assetId) then invoke(getFarmingAddress(),stakeCall(),[],i.payments) else invoke(getFarmingAddress(),JStakeCall(),[],i.payments) 
+    strict stakeDuck = if isJackpot(assetId) then  invoke(getFarmingAddress(),JStakeCall(),[],i.payments) else invoke(getFarmingAddress(),stakeCall(),[],i.payments)
     [
         IntegerEntry(occupiedSpotsDucksHouse(duckHouseId),filledSpots+1),
         StringEntry(keyDuckHouse(assetId.toBase58String()),duckHouseId)
@@ -122,7 +122,7 @@ func unstakeDuck(asset: String)={
     let owner = tryGetString(keyOwner(duckHouseId))
     let address = i.caller.toString()
     if owner != address then throw("Don't try to steal someone duck!") else
-    strict unstakeDuckReward = if isJackpot(asset.fromBase58String()) then invoke(getFarmingAddress(),"unstakeNFT",[asset],[]).asInt() else invoke(getFarmingAddress(),"unstakeJackpot",[asset],[]).asInt()
+    strict unstakeDuckReward = if isJackpot(asset.fromBase58String()) then invoke(getFarmingAddress(),"unstakeJackpot",[asset],[]).asInt() else invoke(getFarmingAddress(),"unstakeNFT",[asset],[]).asInt()
     let filledSpots = tryGetInteger(occupiedSpotsDucksHouse(duckHouseId))
     if filledSpots == 0 then throw("You aren't staking any ducks!") else
     strict unboostDuck = invoke(getItemsAddress(),"manipulateBoost",[-boost(),asset],[])


### PR DESCRIPTION
From tech perspective it's quiet a horrible thing to validate if user has 1 from 4 perches and then stake it.
i propose that jackpot staking through duckhouse can be done without a perch for both duck houses.
